### PR TITLE
Fixed misleading config and variable name 'from_state' is actually 'ticket_type'

### DIFF
--- a/client.conf.example
+++ b/client.conf.example
@@ -11,7 +11,7 @@ secret =  <secret>
 #only set host if you don't wont to use local machine name
 host = None
 url = <tracker url>
-from_state = encoding
+ticket_type = encoding
 to_state = releasing
 
 [voctoweb]

--- a/src/api_client/c3tt_rpc_client.py
+++ b/src/api_client/c3tt_rpc_client.py
@@ -140,14 +140,14 @@ class C3TTClient:
         """
         return str(self._open_rpc("C3TT.getVersion"))
 
-    def assign_next_unassigned_for_state(self, from_state, to_state):
+    def assign_next_unassigned_for_state(self, ticket_type, to_state):
         """
-        check for new ticket on tracker an get assignment
-        :param from_state:
-        :param to_state:
+        check for new ticket on tracker and get assignment
+        :param ticket_type: type of ticket
+        :param to_state: ticket state the returned ticket will be in after this call
         :return:
         """
-        ret = self._open_rpc("C3TT.assignNextUnassignedForState", [from_state, to_state])
+        ret = self._open_rpc("C3TT.assignNextUnassignedForState", [ticket_type, to_state])
         # if we get no xml here there is no ticket for this job
         if not ret:
             return False

--- a/src/script_H_publishing.py
+++ b/src/script_H_publishing.py
@@ -76,7 +76,7 @@ class Publisher:
         else:
             self.host = self.config['C3Tracker']['host']
 
-        self.from_state = self.config['C3Tracker']['from_state']
+        self.ticket_type = self.config['C3Tracker']['ticket_type']
         self.to_state = self.config['C3Tracker']['to_state']
 
         try:
@@ -150,7 +150,7 @@ class Publisher:
         """
         logging.info('requesting ticket from tracker')
 
-        ticket_id = self.c3tt.assign_next_unassigned_for_state(self.from_state, self.to_state)
+        ticket_id = self.c3tt.assign_next_unassigned_for_state(self.ticket_type, self.to_state)
         if ticket_id:
             logging.info("Ticket ID:" + str(ticket_id))
             tracker_ticket = self.c3tt.get_ticket_properties()


### PR DESCRIPTION
This took me a while to find as tracker noob.

Parameters are type and state:
https://repository.fem.tu-ilmenau.de/trac/c3tt/browser/Application/Controller/XMLRPC/Handler.php#L595


Should the old config value be accepted too during a migration phase?