### PR TITLE
download files in chunks to prevent MemoryErrors

### DIFF
--- a/src/script_H_publishing.py
+++ b/src/script_H_publishing.py
@@ -364,7 +364,12 @@ class Publisher:
         with open(file, 'wb') as fh:
             #url = self.ticket.download_url.encode('utf-8')
             with urllib.request.urlopen(urllib.parse.quote(self.ticket.download_url, safe=':/')) as df:
-                fh.write(df.read())
+                # download in 16 kB chunks, to not run out of memory
+                while True:
+                    chunk = df.read(16384)
+                    if not chunk:
+                        break
+                    fh.write(chunk)
 
 
 class PublisherException(Exception):


### PR DESCRIPTION
Currently the whole file is buffered into RAM, when download is done, writing to disk starts. For large files (somewhere above 3 GB) this runs out of memory.
We can instead download in chunks of 16 kB and save them to disk directly. This has already been tested on `live.ber` and works.

Sample stacktrace:
```
Traceback (most recent call last):
  File "./src/script_H_publishing.py", line 392, in <module>
    publisher.download()
  File "./src/script_H_publishing.py", line 160, in download
    self._download_file()
  File "./src/script_H_publishing.py", line 367, in _download_file
    fh.write(df.read())
  File "/usr/lib/python3.4/http/client.py", line 512, in read
    s = self._safe_read(self.length)
  File "/usr/lib/python3.4/http/client.py", line 667, in _safe_read
    return b"".join(s)
MemoryError
```